### PR TITLE
Bugfix: Keypath renamed in JSON Tree

### DIFF
--- a/packages/react-native-query-devtool-app/src/components/JSONTreeSearcheable/index.tsx
+++ b/packages/react-native-query-devtool-app/src/components/JSONTreeSearcheable/index.tsx
@@ -23,6 +23,7 @@ const JSONTreeSearcheable: React.FC<JSONTreeSearcheableProps> = ({ data }) => {
         <JSONTree
           data={data}
           theme={theme}
+          keyPath={["data"]}
           getItemString={(_, currentData) => (
             <span
               dangerouslySetInnerHTML={{ __html: getItemString(currentData) }}


### PR DESCRIPTION
## Pull Request

- [ ] Feature 🎉
- [x] Bug Fix 🐞

## Description
1. Change `keypath` to data instead of `root` 

## Screenshots (if applicable)

#### Before

![Screenshot 2024-03-14 at 9 44 26 PM](https://github.com/jossydeleon/react-native-query-devtool-monorepo/assets/25192002/0a860916-d324-4e53-8f5f-680c884bca07)

#### After

![Screenshot 2024-03-14 at 9 43 52 PM](https://github.com/jossydeleon/react-native-query-devtool-monorepo/assets/25192002/ef913290-7065-4a96-aa4d-52f82240b786)

## Testing

[Describe the testing approach used to verify the changes made in this PR.]
[List any relevant commands or steps to reproduce and validate the changes.]

## Related Issues

[Link any related issues or tasks that are addressed or resolved by this PR.]
